### PR TITLE
Behaviour changes for Non admin role

### DIFF
--- a/IoTDeviceSimulator/web-client/src/App.css
+++ b/IoTDeviceSimulator/web-client/src/App.css
@@ -93,19 +93,6 @@ a:active {
   color: #3d08a1;
 }
 
-.tableStyle {
-  border-style: outset;
-  padding: 10px 10px 10px 10px;
-  white-space: nowrap;
-}
-
-.tableLabelStyle {
-  border-style: outset;
-  padding: 10px 10px 10px 10px;
-  width: 20%;
-  background-color: #cce0d2;
-}
-
 header {
   background-color: #282c34;
   text-align: center;
@@ -279,4 +266,89 @@ header button {
   width: 274px;
   height: 28px;
   margin: 5px 0px;
+}
+
+.tableStyle {
+  border-style: outset;
+  padding: 10px 10px 10px 10px;
+  white-space: nowrap;
+  text-align: center;
+}
+
+.tableLabelStyle {
+  border-style: outset;
+  padding: 10px 10px 10px 10px;
+  text-align: center;
+}
+
+.behaviourComponentStyle {
+  border-style: outset;
+  padding: 10px 10px 10px 10px;
+  text-align: center;
+  vertical-align: middle;
+  border-top-style: hidden;
+}
+
+.behaviourLabelStyle {
+  border-style: outset;
+  padding: 10px 10px 10px 10px;
+  white-space: nowrap;
+  text-align: center;
+  border-top-style: hidden;
+}
+
+.behaviourValueStyle {
+  border-style: outset;
+  padding: 10px 10px 10px 10px;
+  white-space: nowrap;
+  text-align: center;
+}
+.titleStyle{
+  border-style: outset;
+  padding: 10px 10px 10px 10px;
+  white-space: nowrap;
+  text-align: center;
+  background-color: #cce0d2;
+  color: #000;
+}
+
+.non-admin-prop{
+  width:"100%";
+}
+
+.scrollBarStyle {
+  margin-top: 10px;
+  margin-bottom: 10px;
+}
+.scrollBarStyle tbody {
+  display: block;
+  width: 100%;
+  overflow: auto;
+  max-height: 190px;
+}
+
+
+.scrollBarStyle tbody::-webkit-scrollbar {
+  width: 1em;
+}
+ 
+.scrollBarStyle tbody::-webkit-scrollbar-track {
+  box-shadow: inset 0 0 3px rgba(0, 0, 0, 0.3);
+}
+ 
+.scrollBarStyle tbody::-webkit-scrollbar-thumb {
+  background-color: darkgrey;
+  outline: 1px solid slategrey;
+}
+
+td.tableLabelStyle, td.behaviourComponentStyle{
+  width: 92px;
+  min-width: 92px;
+}
+
+table {
+  table-layout: auto;
+  border-collapse: collapse;
+  width: 100%;
+  padding: 10px 0px;
 }

--- a/IoTDeviceSimulator/web-client/src/App.js
+++ b/IoTDeviceSimulator/web-client/src/App.js
@@ -202,16 +202,16 @@ function App() {
       setDeviceTwins([...deviceTwins, device]);
       const newDevice = {
         deviceId: device.deviceId,
-        deviceName: device.properties.desired.deviceName,
-        phenomenon: device.properties.desired.phenomenon,
-        telemetrySendInterval: device.properties.desired.telemetrySendInterval,
-        unit: device.properties.desired.unit,
-        valueIsBool: device.properties.desired.valueIsBool,
-        noiseSd: device.properties.desired.noiseSd,
-        min: device.properties.desired.min,
-        max: device.properties.desired.max,
-        isRunning: device.properties.desired.isRunning,
-        signalArray: device.properties.desired.signalArray,
+        deviceName: device.properties?.desired?.deviceName,
+        phenomenon: device.properties?.desired?.phenomenon,
+        telemetrySendInterval: device.properties?.desired?.telemetrySendInterval,
+        unit: device.properties?.desired?.unit,
+        valueIsBool: device.properties?.desired?.valueIsBool,
+        noiseSd: device.properties?.desired?.noiseSd,
+        min: device.properties?.desired?.min,
+        max: device.properties?.desired?.max,
+        isRunning: device.properties?.desired?.isRunning,
+        signalArray: device.properties?.desired?.signalArray,
       }
       setData([...data, newDevice]);
     }

--- a/IoTDeviceSimulator/web-client/src/BehaviourComponent.js
+++ b/IoTDeviceSimulator/web-client/src/BehaviourComponent.js
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { ChartComponent } from "./ChartComponent";
-import { LabeledInput } from "@itwin/itwinui-react";
+import { LabeledInput, Label } from "@itwin/itwinui-react";
 import { currDataArray } from "./DeviceTwin";
 
 export function SineComponent(props) {
@@ -43,14 +43,32 @@ export function SineComponent(props) {
     }
     return (
         <>
-            <div className="behaviour-value">
-                <LabeledInput className="labels" type='number' label='Mean' name='mean' value={deviceMean} onChange={changeMean} disabled={props.signalArray !== "" ? true : false} />
-                <LabeledInput className="labels" type='number' label='Amplitude' name='amplitude' value={deviceAmplitude} onChange={changeAmplitude} disabled={props.signalArray !== "" ? true : false} />
-                <LabeledInput className="labels" type='number' label='Period(ms)' name='wave_period' value={deviceWavePeriod} onChange={changeWave_period} disabled={props.signalArray !== "" ? true : false} />
-            </div >
-            <ChartComponent labelsArray={arr} dataArray={ar} chartName="Component Signal" />
+            {props.isAdmin === true ?
+            <>
+                <div className="behaviour-value">
+                    <LabeledInput className="labels" type='number' label='Mean' name='mean' value={deviceMean} onChange={changeMean} disabled={props.signalArray !== "" ? true : false} />
+                    <LabeledInput className="labels" type='number' label='Amplitude' name='amplitude' value={deviceAmplitude} onChange={changeAmplitude} disabled={props.signalArray !== "" ? true : false} />
+                    <LabeledInput className="labels" type='number' label='Period(ms)' name='wave_period' value={deviceWavePeriod} onChange={changeWave_period} disabled={props.signalArray !== "" ? true : false} />
+                </div >
+            
+                <ChartComponent labelsArray={arr} dataArray={ar} chartName="Component Signal" />
+            </>
+            : 
+            <>
+                <tr>
+                    <td className="behaviourComponentStyle" rowSpan={2} ><Label>Sine</Label></td>
+                    <td style={{width:"50%"}} className="behaviourLabelStyle"><Label>Mean</Label></td>
+                    <td style={{width:"50%"}} className="behaviourLabelStyle"><Label>Amplitude</Label></td>
+                    <td style={{width:"50%"}} className="behaviourLabelStyle"><Label>Wave Period(ms)</Label></td>
+                </tr>
+                <tr >
+                    <td className="behaviourValueStyle"><Label>{deviceMean}</Label></td>
+                    <td className="behaviourValueStyle"><Label>{deviceAmplitude}</Label></td>
+                    <td className="behaviourValueStyle"><Label>{deviceWavePeriod}</Label></td>
+                </tr>
+            </>
+            }
         </>
-
     );
 }
 
@@ -78,12 +96,26 @@ export function ConstantComponent(props) {
     }
     return (
         <>
-            <div className="behaviour-value">
-                <LabeledInput className="labels" type='number' label='Mean' name='mean' value={deviceMean} onChange={changeMean} disabled={props.signalArray !== "" ? true : false} />
-            </div>
-            <ChartComponent labelsArray={arr} dataArray={ar} chartName="Component Signal" />
+            {props.isAdmin === true ?
+            <>
+                <div className="behaviour-value">
+                    <LabeledInput className="labels" type='number' label='Mean' name='mean' value={deviceMean} onChange={changeMean} disabled={props.signalArray !== "" ? true : false} />
+                </div>
+            
+                <ChartComponent labelsArray={arr} dataArray={ar} chartName="Component Signal" />
+            </>
+                : 
+            <> 
+                <tr style={{width:"100%"}}>
+                    <td className="behaviourComponentStyle" style={{borderTopStyle:"hidden"}} rowSpan={2}><Label>Constant</Label></td>
+                    <td style={{width: "27.6rem",borderTopStyle:"hidden"}} className="behaviourLabelStyle"><Label>Mean</Label></td>
+                </tr>
+                <tr>
+                    <td className="behaviourValueStyle"><Label>{deviceMean}</Label></td>
+                </tr>
+            </>
+            }
         </>
-
     );
 }
 
@@ -112,10 +144,26 @@ export function LinearComponent(props) {
     }
     return (
         <>
-            <div className="behaviour-value">
-                <LabeledInput className="labels" type='number' label='Slope' name='slope' value={deviceSlope} onChange={changeSlope} disabled={props.signalArray !== "" ? true : false} />
-            </div>
-            <ChartComponent labelsArray={arr} dataArray={ar} chartName="Component Signal" />
+            {props.isAdmin === true ?
+            <>
+                <div className="behaviour-value">
+                    <LabeledInput className="labels" type='number' label='Slope' name='slope' value={deviceSlope} onChange={changeSlope} disabled={props.signalArray !== "" ? true : false} />
+                </div>
+
+                <ChartComponent labelsArray={arr} dataArray={ar} chartName="Component Signal" />
+            </>
+            : 
+            <>
+                <tr>
+                    <td className="behaviourComponentStyle" rowSpan={2}><Label>Linear</Label></td>
+                    <td style={{width: "27.6rem"}} className="behaviourLabelStyle"><Label>Slope</Label></td>
+                    
+                </tr>
+                <tr>
+                    <td className="behaviourValueStyle"><Label>{deviceSlope}</Label></td>
+                </tr>
+            </>
+            }
         </>
 
     );
@@ -152,11 +200,29 @@ export function NoiseComponent(props) {
     }
     return (
         <>
-            <div className="behaviour-value">
-                <LabeledInput className="labels" type='number' label='Magnitude' name='noise_magnitude' value={deviceNoiseMagnitude} onChange={changeNoise_magnitude} disabled={props.signalArray !== "" ? true : false} />
-                <LabeledInput className="labels" type='number' label='Deviation' name='noiseSd' value={0.45} disabled={true} />
-            </div>
-            <ChartComponent labelsArray={arr} dataArray={ar} chartName="Component Signal" />
+            {props.isAdmin === true ?
+            <>
+                <div className="behaviour-value">
+                    <LabeledInput className="labels" type='number' label='Magnitude' name='noise_magnitude' value={deviceNoiseMagnitude} onChange={changeNoise_magnitude} disabled={props.signalArray !== "" ? true : false} />
+                    <LabeledInput className="labels" type='number' label='Deviation' name='noiseSd' value={0.45} disabled={true} />
+                </div>
+
+                <ChartComponent labelsArray={arr} dataArray={ar} chartName="Component Signal" />
+            </>
+            : 
+            <>
+                <tr>
+                    <td className="behaviourComponentStyle" rowSpan={2}><Label>Noise</Label></td>
+                    <td style={{width:"50%"}} className="behaviourLabelStyle"><Label>Magnitude</Label></td>
+                    <td style={{width:"50%"}} className="behaviourLabelStyle"><Label>Deviation</Label></td>
+                    
+                </tr>
+                <tr>
+                    <td className="behaviourValueStyle"><Label>{deviceNoiseMagnitude}</Label></td>
+                    <td className="behaviourValueStyle"><Label>{0.45}</Label></td>
+                </tr>
+            </>
+            }
         </>
     );
 
@@ -195,11 +261,28 @@ export function TriangularComponent(props) {
     }
     return (
         <>
-            <div className="behaviour-value">
-                <LabeledInput className="labels" type='number' label='Amplitude' name='amplitude' value={deviceAmplitude} onChange={changeAmplitude} disabled={props.signalArray !== "" ? true : false} />
-                <LabeledInput className="labels" type='number' label='Period(ms)' name='wave_period' value={deviceWavePeriod} onChange={changeWave_period} disabled={props.signalArray !== "" ? true : false} />
-            </div>
-            <ChartComponent labelsArray={arr} dataArray={ar} chartName="Component Signal" />
+            {props.isAdmin === true ?
+            <>
+                <div className="behaviour-value">
+                    <LabeledInput className="labels" type='number' label='Amplitude' name='amplitude' value={deviceAmplitude} onChange={changeAmplitude} disabled={props.signalArray !== "" ? true : false} />
+                    <LabeledInput className="labels" type='number' label='Period(ms)' name='wave_period' value={deviceWavePeriod} onChange={changeWave_period} disabled={props.signalArray !== "" ? true : false} />
+                </div>
+
+                <ChartComponent labelsArray={arr} dataArray={ar} chartName="Component Signal" />
+            </>
+            : 
+            <>
+                <tr>
+                    <td className="behaviourComponentStyle" rowSpan={2}><Label>Triangular</Label></td>
+                    <td style={{width:"50%", paddingRight: "49px"}} className="behaviourLabelStyle"><Label>Amplitude</Label></td>
+                    <td style={{width:"50%", paddingLeft: "0px"}} className="behaviourLabelStyle"><Label>Wave Period(ms)</Label></td>
+                </tr>
+                <tr>
+                    <td className="behaviourValueStyle"><Label>{deviceAmplitude}</Label></td>
+                    <td className="behaviourValueStyle"><Label>{deviceWavePeriod}</Label></td>
+                </tr>
+            </>
+            }
         </>
     );
 
@@ -239,11 +322,29 @@ export function SawToothComponent(props) {
     }
     return (
         <>
-            <div className="behaviour-value">
-                <LabeledInput className="labels" type='number' label='Amplitude' name='amplitude' value={deviceAmplitude} onChange={changeAmplitude} disabled={props.signalArray !== "" ? true : false} />
-                <LabeledInput className="labels" type='number' label='Period(ms)' name='wave_period' value={deviceWavePeriod} onChange={changeWave_period} disabled={props.signalArray !== "" ? true : false} />
-            </div>
-            <ChartComponent labelsArray={arr} dataArray={ar} chartName="Component Signal" />
+            {props.isAdmin === true ?
+            <>
+                <div className="behaviour-value">
+                    <LabeledInput className="labels" type='number' label='Amplitude' name='amplitude' value={deviceAmplitude} onChange={changeAmplitude} disabled={props.signalArray !== "" ? true : false} />
+                    <LabeledInput className="labels" type='number' label='Period(ms)' name='wave_period' value={deviceWavePeriod} onChange={changeWave_period} disabled={props.signalArray !== "" ? true : false} />
+                </div>
+
+                <ChartComponent labelsArray={arr} dataArray={ar} chartName="Component Signal" />
+            </>
+            : 
+            <>
+                <tr>
+                    <td className="behaviourComponentStyle" rowSpan={2}><Label>SawTooth</Label></td>
+                    <td style={{width:"50%",paddingRight: "49px"}} className="behaviourLabelStyle"><Label>Amplitude</Label></td>
+                    <td style={{width:"50%",paddingLeft: "0px"}} className="behaviourLabelStyle"><Label>Wave Period(ms)</Label></td>
+                    
+                </tr>
+                <tr>
+                    <td className="behaviourValueStyle"><Label>{deviceAmplitude}</Label></td>
+                    <td className="behaviourValueStyle"><Label>{deviceWavePeriod}</Label></td>
+                </tr>
+            </>
+            }
         </>
     );
 
@@ -282,39 +383,64 @@ export function SquareComponent(props) {
     }
     return (
         <>
-            <div className="behaviour-value">
-                <LabeledInput className="labels" type='number' label='Amplitude' name='amplitude' value={deviceAmplitude} onChange={changeAmplitude} disabled={props.signalArray !== "" ? true : false} />
-                <LabeledInput className="labels" type='number' label='Period(ms)' name='wave_period' value={deviceWavePeriod} onChange={changeWave_period} disabled={props.signalArray !== "" ? true : false} />
-            </div>
-            <ChartComponent labelsArray={arr} dataArray={ar} chartName="Component Signal" />
+            {props.isAdmin === true ?
+            <>
+                <div className="behaviour-value">
+                    <LabeledInput className="labels" type='number' label='Amplitude' name='amplitude' value={deviceAmplitude} onChange={changeAmplitude} disabled={props.signalArray !== "" ? true : false} />
+                    <LabeledInput className="labels" type='number' label='Period(ms)' name='wave_period' value={deviceWavePeriod} onChange={changeWave_period} disabled={props.signalArray !== "" ? true : false} />
+                </div>
+                
+                <ChartComponent labelsArray={arr} dataArray={ar} chartName="Component Signal" />
+            </>
+            : 
+            <>
+                <tr>
+                    <td className="behaviourComponentStyle" style={{borderBottomStyle:"outset"}} rowSpan={2}><Label>Square</Label></td>
+                    <td style={{width:"50%",paddingRight: "49px"}} className="behaviourLabelStyle"><Label>Amplitude</Label></td>
+                    <td style={{width:"50%",paddingLeft: "0px"}} className="behaviourLabelStyle"><Label>Wave Period(ms)</Label></td>
+                </tr>
+                <tr>
+                    <td className="behaviourValueStyle" style={{borderBottomStyle:"outset"}}><Label>{deviceAmplitude}</Label></td>
+                    <td className="behaviourValueStyle" style={{borderBottomStyle:"outset"}}><Label>{deviceWavePeriod}</Label></td>
+                </tr>
+            </>
+            }
         </>
     );
 
 }
 
 export function BehaviourComponent(props) {
-    // const signalArray=`{"Behaviour":"Sine","Mean":100,"Amplitude":10, "Wave Period":20000}`    
+    let behaviourObject; 
+    switch(props.behaviour){
+        case "Sine":
+            behaviourObject = <SineComponent arrayLength={props.arrayLength} telemetrySendInterval={props.telemetrySendInterval} signalArray={props.signalArray} setCurrDataArray={props.setCurrDataArray} newBehaviour = {props.newBehaviour} isAdmin={props.isAdmin} />
+            break;
+        case "Constant":
+            behaviourObject = <ConstantComponent arrayLength={props.arrayLength} telemetrySendInterval={props.telemetrySendInterval} signalArray={props.signalArray} setCurrDataArray={props.setCurrDataArray} newBehaviour = {props.newBehaviour} isAdmin={props.isAdmin} />
+            break;
+        case "Linear":
+            behaviourObject =  <LinearComponent arrayLength={props.arrayLength} telemetrySendInterval={props.telemetrySendInterval} signalArray={props.signalArray} setCurrDataArray={props.setCurrDataArray} newBehaviour = {props.newBehaviour} isAdmin={props.isAdmin} />
+            break;
+        case "Noise":
+            behaviourObject = <NoiseComponent arrayLength={props.arrayLength} telemetrySendInterval={props.telemetrySendInterval} signalArray={props.signalArray} setCurrDataArray={props.setCurrDataArray} newBehaviour = {props.newBehaviour} isAdmin={props.isAdmin} />
+            break;
+        case "Triangular":
+            behaviourObject = <TriangularComponent arrayLength={props.arrayLength} telemetrySendInterval={props.telemetrySendInterval} signalArray={props.signalArray} setCurrDataArray={props.setCurrDataArray} newBehaviour = {props.newBehaviour} isAdmin={props.isAdmin} />
+            break;
+        case "Sawtooth":
+            behaviourObject = <SawToothComponent arrayLength={props.arrayLength} telemetrySendInterval={props.telemetrySendInterval} signalArray={props.signalArray} setCurrDataArray={props.setCurrDataArray} newBehaviour = {props.newBehaviour} isAdmin={props.isAdmin} />
+            break;
+        case "Square":
+            behaviourObject =  <SquareComponent arrayLength={props.arrayLength} telemetrySendInterval={props.telemetrySendInterval} signalArray={props.signalArray} setCurrDataArray={props.setCurrDataArray} newBehaviour = {props.newBehaviour} isAdmin={props.isAdmin} /> 
+            break;
+        default:
+            behaviourObject = null;
+    }
+            
     return (
-        <div className="behaviour-prop">
-            {
-                props.behaviour === "Sine" ?
-                    <SineComponent arrayLength={props.arrayLength} telemetrySendInterval={props.telemetrySendInterval} signalArray={props.signalArray} setCurrDataArray={props.setCurrDataArray} newBehaviour = {props.newBehaviour}/>
-                : props.behaviour === "Constant" ?
-                    <ConstantComponent arrayLength={props.arrayLength} telemetrySendInterval={props.telemetrySendInterval} signalArray={props.signalArray} setCurrDataArray={props.setCurrDataArray} newBehaviour = {props.newBehaviour} />
-                : props.behaviour === "Linear" ?
-                    <LinearComponent arrayLength={props.arrayLength} telemetrySendInterval={props.telemetrySendInterval} signalArray={props.signalArray} setCurrDataArray={props.setCurrDataArray} newBehaviour = {props.newBehaviour} />
-                : props.behaviour === "Noise" ?
-                    <NoiseComponent arrayLength={props.arrayLength} telemetrySendInterval={props.telemetrySendInterval} signalArray={props.signalArray} setCurrDataArray={props.setCurrDataArray} newBehaviour = {props.newBehaviour} />
-                : props.behaviour === "Triangular" ?
-                    <TriangularComponent arrayLength={props.arrayLength} telemetrySendInterval={props.telemetrySendInterval} signalArray={props.signalArray} setCurrDataArray={props.setCurrDataArray} newBehaviour = {props.newBehaviour} />
-                : props.behaviour === "Sawtooth" ?
-                    <SawToothComponent arrayLength={props.arrayLength} telemetrySendInterval={props.telemetrySendInterval} signalArray={props.signalArray} setCurrDataArray={props.setCurrDataArray} newBehaviour = {props.newBehaviour} />
-                : props.behaviour === "Square" ?
-                    <SquareComponent arrayLength={props.arrayLength} telemetrySendInterval={props.telemetrySendInterval} signalArray={props.signalArray} setCurrDataArray={props.setCurrDataArray} newBehaviour = {props.newBehaviour} />
-                : null
-            }
+        <div className={props.isAdmin?"behaviour-prop":"non-admin-prop"}>
+            {behaviourObject}  
         </div>
-
     );
-
 }

--- a/IoTDeviceSimulator/web-client/src/BehaviourComponent.js
+++ b/IoTDeviceSimulator/web-client/src/BehaviourComponent.js
@@ -26,9 +26,9 @@ export function SineComponent(props) {
     }
 
     const phase = 0;
-    const deviceMean = props.signalArray !== "" ? JSON.parse(props.signalArray)["Mean"] : mean;
-    const deviceAmplitude = props.signalArray !== "" ? JSON.parse(props.signalArray)["Amplitude"] : amplitude;
-    const deviceWavePeriod = props.signalArray !== "" ? JSON.parse(props.signalArray)["Wave Period"] : wave_period;
+    const deviceMean = props.signalArray !== "" ? JSON.parse(props.signalArray)["Mean"] : mean !==""? mean: props.newBehaviour !=="" ? JSON.parse(props.newBehaviour)["Mean"]: mean;
+    const deviceAmplitude = props.signalArray !== "" ? JSON.parse(props.signalArray)["Amplitude"] : amplitude !=="" ? amplitude: props.newBehaviour !=="" ? JSON.parse(props.newBehaviour)["Amplitude"]: amplitude;
+    const deviceWavePeriod = props.signalArray !== "" ? JSON.parse(props.signalArray)["Wave Period"] : wave_period !=="" ? wave_period: props.newBehaviour !=="" ? JSON.parse(props.newBehaviour)["Wave Period"]: wave_period;
     if (deviceMean !== "" && deviceAmplitude !== "" && deviceWavePeriod !== "") {
         for (let i = 0; i < parseFloat(props.arrayLength); i++) {
             let currData = parseFloat(deviceMean) + Math.sin((i * (parseFloat(props.telemetrySendInterval) / 1000)) * (2 * Math.PI) / (parseFloat(deviceWavePeriod) / 1000) + phase) * parseFloat(deviceAmplitude);
@@ -65,7 +65,7 @@ export function ConstantComponent(props) {
     for (let i = 0; i < parseFloat(props.arrayLength); i++) {
         arr.push(i * (parseFloat(props.telemetrySendInterval)) / 1000);
     }
-    const deviceMean = props.signalArray !== "" ? JSON.parse(props.signalArray)["Mean"] : mean;
+    const deviceMean = props.signalArray !== "" ? JSON.parse(props.signalArray)["Mean"]: mean !==""? mean: props.newBehaviour !=="" ? JSON.parse(props.newBehaviour)["Mean"] : mean;
     if (deviceMean !== "") {
         for (let i = 0; i < props.arrayLength; i++) {
             let currData = parseFloat(deviceMean);
@@ -99,7 +99,7 @@ export function LinearComponent(props) {
         arr.push(i * (parseFloat(props.telemetrySendInterval)) / 1000);
     }
 
-    const deviceSlope = props.signalArray !== "" ? JSON.parse(props.signalArray)["Slope"] : slope;
+    const deviceSlope = props.signalArray !== "" ? JSON.parse(props.signalArray)["Slope"]: slope !==""? slope: props.newBehaviour !=="" ? JSON.parse(props.newBehaviour)["Slope"] : slope;
     if (deviceSlope !== "") {
         for (let i = 0; i < parseFloat(props.arrayLength); i++) {
             let currData = parseFloat(deviceSlope) * ((i * (parseFloat(props.telemetrySendInterval) / 1000)));
@@ -134,7 +134,7 @@ export function NoiseComponent(props) {
         arr.push(i * (parseFloat(props.telemetrySendInterval)) / 1000);
     }
 
-    const deviceNoiseMagnitude = props.signalArray !== "" ? JSON.parse(props.signalArray)["Noise Magnitude"] : noise_magnitude;
+    const deviceNoiseMagnitude = props.signalArray !== "" ? JSON.parse(props.signalArray)["Noise Magnitude"]: noise_magnitude !==""? noise_magnitude: props.newBehaviour !=="" ? JSON.parse(props.newBehaviour)["Noise Magnitude"] : noise_magnitude;
     if (deviceNoiseMagnitude !== "") {
         let mean = 0;
         let standard_deviation = 0.45;
@@ -181,8 +181,8 @@ export function TriangularComponent(props) {
         arr.push(i * (parseFloat(props.telemetrySendInterval)) / 1000);
     }
 
-    const deviceAmplitude = props.signalArray !== "" ? JSON.parse(props.signalArray)["Amplitude"] : amplitude;
-    const deviceWavePeriod = props.signalArray !== "" ? JSON.parse(props.signalArray)["Wave Period"] : wave_period;
+    const deviceAmplitude = props.signalArray !== "" ? JSON.parse(props.signalArray)["Amplitude"] : amplitude !==""? amplitude: props.newBehaviour !=="" ? JSON.parse(props.newBehaviour)["Amplitude"]: amplitude;
+    const deviceWavePeriod = props.signalArray !== "" ? JSON.parse(props.signalArray)["Wave Period"] : wave_period !==""? wave_period: props.newBehaviour !=="" ? JSON.parse(props.newBehaviour)["Wave Period"]: wave_period;
     if (deviceAmplitude !== "" && deviceWavePeriod !== "") {
         for (let i = 0; i < parseFloat(props.arrayLength); i++) {
             let currData = (2 * parseFloat(deviceAmplitude) * Math.asin(Math.sin((2 * Math.PI * (i * (parseFloat(props.telemetrySendInterval) / 1000))) / (parseFloat(deviceWavePeriod) / 1000)))) / Math.PI;
@@ -225,8 +225,8 @@ export function SawToothComponent(props) {
         arr.push(i * (parseFloat(props.telemetrySendInterval)) / 1000);
     }
 
-    const deviceAmplitude = props.signalArray !== "" ? JSON.parse(props.signalArray)["Amplitude"] : amplitude;
-    const deviceWavePeriod = props.signalArray !== "" ? JSON.parse(props.signalArray)["Wave Period"] : wave_period;
+    const deviceAmplitude = props.signalArray !== "" ? JSON.parse(props.signalArray)["Amplitude"] : amplitude !==""? amplitude: props.newBehaviour !=="" ? JSON.parse(props.newBehaviour)["Amplitude"]: amplitude;
+    const deviceWavePeriod = props.signalArray !== "" ? JSON.parse(props.signalArray)["Wave Period"] : wave_period !==""? wave_period: props.newBehaviour !=="" ? JSON.parse(props.newBehaviour)["Wave Period"]: wave_period;
     if (deviceAmplitude !== "" && deviceWavePeriod !== "") {
         for (let i = 0; i < parseFloat(props.arrayLength); i++) {
             let currData = 2 * parseFloat(deviceAmplitude) * ((i * (parseFloat(props.telemetrySendInterval) / 1000)) / (parseFloat(deviceWavePeriod) / 1000) - Math.floor(1 / 2 + (i * (parseFloat(props.telemetrySendInterval) / 1000)) / (parseFloat(deviceWavePeriod) / 1000)));
@@ -268,8 +268,8 @@ export function SquareComponent(props) {
         arr.push(i * (parseFloat(props.telemetrySendInterval)) / 1000);
     }
 
-    const deviceAmplitude = props.signalArray !== "" ? JSON.parse(props.signalArray)["Amplitude"] : amplitude;
-    const deviceWavePeriod = props.signalArray !== "" ? JSON.parse(props.signalArray)["Wave Period"] : wave_period;
+    const deviceAmplitude = props.signalArray !== "" ? JSON.parse(props.signalArray)["Amplitude"]: amplitude !==""? amplitude: props.newBehaviour !=="" ? JSON.parse(props.newBehaviour)["Amplitude"] : amplitude;
+    const deviceWavePeriod = props.signalArray !== "" ? JSON.parse(props.signalArray)["Wave Period"] : wave_period !==""? wave_period: props.newBehaviour !=="" ? JSON.parse(props.newBehaviour)["Wave Period"]: wave_period;
     if (deviceAmplitude !== "" && deviceWavePeriod !== "") {
         for (let i = 0; i < parseFloat(props.arrayLength); i++) {
             let currData = parseFloat(deviceAmplitude) * Math.sign(Math.sin((2 * Math.PI * (i * (parseFloat(props.telemetrySendInterval) / 1000))) / (parseFloat(deviceWavePeriod) / 1000)));
@@ -298,19 +298,19 @@ export function BehaviourComponent(props) {
         <div className="behaviour-prop">
             {
                 props.behaviour === "Sine" ?
-                    <SineComponent arrayLength={props.arrayLength} telemetrySendInterval={props.telemetrySendInterval} signalArray={props.signalArray} setCurrDataArray={props.setCurrDataArray} />
+                    <SineComponent arrayLength={props.arrayLength} telemetrySendInterval={props.telemetrySendInterval} signalArray={props.signalArray} setCurrDataArray={props.setCurrDataArray} newBehaviour = {props.newBehaviour}/>
                 : props.behaviour === "Constant" ?
-                    <ConstantComponent arrayLength={props.arrayLength} telemetrySendInterval={props.telemetrySendInterval} signalArray={props.signalArray} setCurrDataArray={props.setCurrDataArray} />
+                    <ConstantComponent arrayLength={props.arrayLength} telemetrySendInterval={props.telemetrySendInterval} signalArray={props.signalArray} setCurrDataArray={props.setCurrDataArray} newBehaviour = {props.newBehaviour} />
                 : props.behaviour === "Linear" ?
-                    <LinearComponent arrayLength={props.arrayLength} telemetrySendInterval={props.telemetrySendInterval} signalArray={props.signalArray} setCurrDataArray={props.setCurrDataArray} />
+                    <LinearComponent arrayLength={props.arrayLength} telemetrySendInterval={props.telemetrySendInterval} signalArray={props.signalArray} setCurrDataArray={props.setCurrDataArray} newBehaviour = {props.newBehaviour} />
                 : props.behaviour === "Noise" ?
-                    <NoiseComponent arrayLength={props.arrayLength} telemetrySendInterval={props.telemetrySendInterval} signalArray={props.signalArray} setCurrDataArray={props.setCurrDataArray} />
+                    <NoiseComponent arrayLength={props.arrayLength} telemetrySendInterval={props.telemetrySendInterval} signalArray={props.signalArray} setCurrDataArray={props.setCurrDataArray} newBehaviour = {props.newBehaviour} />
                 : props.behaviour === "Triangular" ?
-                    <TriangularComponent arrayLength={props.arrayLength} telemetrySendInterval={props.telemetrySendInterval} signalArray={props.signalArray} setCurrDataArray={props.setCurrDataArray} />
+                    <TriangularComponent arrayLength={props.arrayLength} telemetrySendInterval={props.telemetrySendInterval} signalArray={props.signalArray} setCurrDataArray={props.setCurrDataArray} newBehaviour = {props.newBehaviour} />
                 : props.behaviour === "Sawtooth" ?
-                    <SawToothComponent arrayLength={props.arrayLength} telemetrySendInterval={props.telemetrySendInterval} signalArray={props.signalArray} setCurrDataArray={props.setCurrDataArray} />
+                    <SawToothComponent arrayLength={props.arrayLength} telemetrySendInterval={props.telemetrySendInterval} signalArray={props.signalArray} setCurrDataArray={props.setCurrDataArray} newBehaviour = {props.newBehaviour} />
                 : props.behaviour === "Square" ?
-                    <SquareComponent arrayLength={props.arrayLength} telemetrySendInterval={props.telemetrySendInterval} signalArray={props.signalArray} setCurrDataArray={props.setCurrDataArray} />
+                    <SquareComponent arrayLength={props.arrayLength} telemetrySendInterval={props.telemetrySendInterval} signalArray={props.signalArray} setCurrDataArray={props.setCurrDataArray} newBehaviour = {props.newBehaviour} />
                 : null
             }
         </div>

--- a/IoTDeviceSimulator/web-client/src/BehaviourComponent.js
+++ b/IoTDeviceSimulator/web-client/src/BehaviourComponent.js
@@ -1,0 +1,320 @@
+import React, { useState } from "react";
+import { ChartComponent } from "./ChartComponent";
+import { LabeledInput } from "@itwin/itwinui-react";
+import { currDataArray } from "./DeviceTwin";
+
+export function SineComponent(props) {
+    const [mean, setMean] = useState("");
+    const [amplitude, setAmplitude] = useState("");
+    const [wave_period, setWave_period] = useState("");
+    const changeMean = (event) => {
+        setMean(event.target.value);
+    }
+
+    const changeAmplitude = (event) => {
+        setAmplitude(event.target.value);
+    }
+
+    const changeWave_period = (event) => {
+        setWave_period(event.target.value);
+    }
+    const ar = [];
+    const arr = [];
+
+    for (let i = 0; i < parseFloat(props.arrayLength); i++) {
+        arr.push(i * (parseFloat(props.telemetrySendInterval)) / 1000);
+    }
+
+    const phase = 0;
+    const deviceMean = props.signalArray !== "" ? JSON.parse(props.signalArray)["Mean"] : mean;
+    const deviceAmplitude = props.signalArray !== "" ? JSON.parse(props.signalArray)["Amplitude"] : amplitude;
+    const deviceWavePeriod = props.signalArray !== "" ? JSON.parse(props.signalArray)["Wave Period"] : wave_period;
+    if (deviceMean !== "" && deviceAmplitude !== "" && deviceWavePeriod !== "") {
+        for (let i = 0; i < parseFloat(props.arrayLength); i++) {
+            let currData = parseFloat(deviceMean) + Math.sin((i * (parseFloat(props.telemetrySendInterval) / 1000)) * (2 * Math.PI) / (parseFloat(deviceWavePeriod) / 1000) + phase) * parseFloat(deviceAmplitude);
+            ar.push(currData);
+        }
+        if (props.signalArray === "") {
+            const sineObj = `{"Behaviour":"Sine","Mean":${deviceMean},"Amplitude":${deviceAmplitude},"Wave Period":${deviceWavePeriod},"Phase":"0"}`;
+            props.setCurrDataArray(ar, sineObj);
+        }
+
+        console.log("After Modification " + currDataArray);
+    }
+    return (
+        <>
+            <div className="behaviour-value">
+                <LabeledInput className="labels" type='number' label='Mean' name='mean' value={deviceMean} onChange={changeMean} disabled={props.signalArray !== "" ? true : false} />
+                <LabeledInput className="labels" type='number' label='Amplitude' name='amplitude' value={deviceAmplitude} onChange={changeAmplitude} disabled={props.signalArray !== "" ? true : false} />
+                <LabeledInput className="labels" type='number' label='Period(ms)' name='wave_period' value={deviceWavePeriod} onChange={changeWave_period} disabled={props.signalArray !== "" ? true : false} />
+            </div >
+            <ChartComponent labelsArray={arr} dataArray={ar} chartName="Component Signal" />
+        </>
+
+    );
+}
+
+export function ConstantComponent(props) {
+    const [mean, setMean] = useState("");
+    const changeMean = (event) => {
+        setMean(event.target.value);
+    }
+    const ar = [];
+    const arr = [];
+
+    for (let i = 0; i < parseFloat(props.arrayLength); i++) {
+        arr.push(i * (parseFloat(props.telemetrySendInterval)) / 1000);
+    }
+    const deviceMean = props.signalArray !== "" ? JSON.parse(props.signalArray)["Mean"] : mean;
+    if (deviceMean !== "") {
+        for (let i = 0; i < props.arrayLength; i++) {
+            let currData = parseFloat(deviceMean);
+            ar.push(currData);
+        }
+        if (props.signalArray === "") {
+            const constObj = `{"Behaviour":"Constant","Mean":${deviceMean}}`;
+            props.setCurrDataArray(ar, constObj);
+        }
+    }
+    return (
+        <>
+            <div className="behaviour-value">
+                <LabeledInput className="labels" type='number' label='Mean' name='mean' value={deviceMean} onChange={changeMean} disabled={props.signalArray !== "" ? true : false} />
+            </div>
+            <ChartComponent labelsArray={arr} dataArray={ar} chartName="Component Signal" />
+        </>
+
+    );
+}
+
+export function LinearComponent(props) {
+    const [slope, setSlope] = useState("");
+    const changeSlope = (event) => {
+        setSlope(event.target.value);
+    }
+    const ar = [];
+    const arr = [];
+
+    for (let i = 0; i < parseFloat(props.arrayLength); i++) {
+        arr.push(i * (parseFloat(props.telemetrySendInterval)) / 1000);
+    }
+
+    const deviceSlope = props.signalArray !== "" ? JSON.parse(props.signalArray)["Slope"] : slope;
+    if (deviceSlope !== "") {
+        for (let i = 0; i < parseFloat(props.arrayLength); i++) {
+            let currData = parseFloat(deviceSlope) * ((i * (parseFloat(props.telemetrySendInterval) / 1000)));
+            ar.push(currData);
+        }
+        if (props.signalArray === "") {
+            const linearObj = `{"Behaviour":"Linear","Slope":${deviceSlope}}`;
+            props.setCurrDataArray(ar, linearObj);
+        }
+    }
+    return (
+        <>
+            <div className="behaviour-value">
+                <LabeledInput className="labels" type='number' label='Slope' name='slope' value={deviceSlope} onChange={changeSlope} disabled={props.signalArray !== "" ? true : false} />
+            </div>
+            <ChartComponent labelsArray={arr} dataArray={ar} chartName="Component Signal" />
+        </>
+
+    );
+}
+
+export function NoiseComponent(props) {
+    const [noise_magnitude, setNoise_magnitude] = useState("");
+    const changeNoise_magnitude = (event) => {
+        setNoise_magnitude(event.target.value);
+    }
+
+    const ar = [];
+    const arr = [];
+
+    for (let i = 0; i < parseFloat(props.arrayLength); i++) {
+        arr.push(i * (parseFloat(props.telemetrySendInterval)) / 1000);
+    }
+
+    const deviceNoiseMagnitude = props.signalArray !== "" ? JSON.parse(props.signalArray)["Noise Magnitude"] : noise_magnitude;
+    if (deviceNoiseMagnitude !== "") {
+        let mean = 0;
+        let standard_deviation = 0.45;
+        for (let i = 0; i < parseFloat(props.arrayLength); i++) {
+            let x = (Math.random() - 0.5) * 2;
+            let noise = (1 / (Math.sqrt(2 * Math.PI) * standard_deviation)) * Math.pow(Math.E, -1 * Math.pow((x - mean) / standard_deviation, 2) / 2);
+            let noise_mag = deviceNoiseMagnitude * Math.sign((Math.random() - 0.5) * 2);
+            let currData = noise * noise_mag;
+            ar.push(currData);
+        }
+        if (props.signalArray === "") {
+            const noiseObj = `{"Behaviour":"Noise","Noise Magnitude":${deviceNoiseMagnitude},"Noise Standard-deviation":0.45}`;
+            props.setCurrDataArray(ar, noiseObj);
+        }
+    }
+    return (
+        <>
+            <div className="behaviour-value">
+                <LabeledInput className="labels" type='number' label='Magnitude' name='noise_magnitude' value={deviceNoiseMagnitude} onChange={changeNoise_magnitude} disabled={props.signalArray !== "" ? true : false} />
+                <LabeledInput className="labels" type='number' label='Deviation' name='noiseSd' value={0.45} disabled={true} />
+            </div>
+            <ChartComponent labelsArray={arr} dataArray={ar} chartName="Component Signal" />
+        </>
+    );
+
+}
+
+export function TriangularComponent(props) {
+    const [amplitude, setAmplitude] = useState("");
+    const [wave_period, setWave_period] = useState("");
+
+    const changeAmplitude = (event) => {
+        setAmplitude(event.target.value);
+    }
+
+    const changeWave_period = (event) => {
+        setWave_period(event.target.value);
+    }
+
+    const ar = [];
+    const arr = [];
+
+    for (let i = 0; i < parseFloat(props.arrayLength); i++) {
+        arr.push(i * (parseFloat(props.telemetrySendInterval)) / 1000);
+    }
+
+    const deviceAmplitude = props.signalArray !== "" ? JSON.parse(props.signalArray)["Amplitude"] : amplitude;
+    const deviceWavePeriod = props.signalArray !== "" ? JSON.parse(props.signalArray)["Wave Period"] : wave_period;
+    if (deviceAmplitude !== "" && deviceWavePeriod !== "") {
+        for (let i = 0; i < parseFloat(props.arrayLength); i++) {
+            let currData = (2 * parseFloat(deviceAmplitude) * Math.asin(Math.sin((2 * Math.PI * (i * (parseFloat(props.telemetrySendInterval) / 1000))) / (parseFloat(deviceWavePeriod) / 1000)))) / Math.PI;
+            ar.push(currData);
+        }
+        if (props.signalArray === "") {
+            const triangularObj = `{"Behaviour":"Triangular","Amplitude":${deviceAmplitude},"Wave Period":${deviceWavePeriod}}`;
+            props.setCurrDataArray(ar, triangularObj);
+        }
+    }
+    return (
+        <>
+            <div className="behaviour-value">
+                <LabeledInput className="labels" type='number' label='Amplitude' name='amplitude' value={deviceAmplitude} onChange={changeAmplitude} disabled={props.signalArray !== "" ? true : false} />
+                <LabeledInput className="labels" type='number' label='Period(ms)' name='wave_period' value={deviceWavePeriod} onChange={changeWave_period} disabled={props.signalArray !== "" ? true : false} />
+            </div>
+            <ChartComponent labelsArray={arr} dataArray={ar} chartName="Component Signal" />
+        </>
+    );
+
+}
+
+
+export function SawToothComponent(props) {
+    const [amplitude, setAmplitude] = useState("");
+    const [wave_period, setWave_period] = useState("");
+
+    const changeAmplitude = (event) => {
+        setAmplitude(event.target.value);
+    }
+
+    const changeWave_period = (event) => {
+        setWave_period(event.target.value);
+    }
+
+    const ar = [];
+    const arr = [];
+
+    for (let i = 0; i < parseFloat(props.arrayLength); i++) {
+        arr.push(i * (parseFloat(props.telemetrySendInterval)) / 1000);
+    }
+
+    const deviceAmplitude = props.signalArray !== "" ? JSON.parse(props.signalArray)["Amplitude"] : amplitude;
+    const deviceWavePeriod = props.signalArray !== "" ? JSON.parse(props.signalArray)["Wave Period"] : wave_period;
+    if (deviceAmplitude !== "" && deviceWavePeriod !== "") {
+        for (let i = 0; i < parseFloat(props.arrayLength); i++) {
+            let currData = 2 * parseFloat(deviceAmplitude) * ((i * (parseFloat(props.telemetrySendInterval) / 1000)) / (parseFloat(deviceWavePeriod) / 1000) - Math.floor(1 / 2 + (i * (parseFloat(props.telemetrySendInterval) / 1000)) / (parseFloat(deviceWavePeriod) / 1000)));
+            ar.push(currData);
+        }
+        if (props.signalArray === "") {
+            const sawtoothObj = `{"Behaviour":"Sawtooth","Amplitude":${deviceAmplitude},"Wave Period":${deviceWavePeriod}}`;
+            props.setCurrDataArray(ar, sawtoothObj);
+        }
+    }
+    return (
+        <>
+            <div className="behaviour-value">
+                <LabeledInput className="labels" type='number' label='Amplitude' name='amplitude' value={deviceAmplitude} onChange={changeAmplitude} disabled={props.signalArray !== "" ? true : false} />
+                <LabeledInput className="labels" type='number' label='Period(ms)' name='wave_period' value={deviceWavePeriod} onChange={changeWave_period} disabled={props.signalArray !== "" ? true : false} />
+            </div>
+            <ChartComponent labelsArray={arr} dataArray={ar} chartName="Component Signal" />
+        </>
+    );
+
+}
+
+export function SquareComponent(props) {
+    const [amplitude, setAmplitude] = useState("");
+    const [wave_period, setWave_period] = useState("");
+
+    const changeAmplitude = (event) => {
+        setAmplitude(event.target.value);
+    }
+
+    const changeWave_period = (event) => {
+        setWave_period(event.target.value);
+    }
+
+    const ar = [];
+    const arr = [];
+
+    for (let i = 0; i < parseFloat(props.arrayLength); i++) {
+        arr.push(i * (parseFloat(props.telemetrySendInterval)) / 1000);
+    }
+
+    const deviceAmplitude = props.signalArray !== "" ? JSON.parse(props.signalArray)["Amplitude"] : amplitude;
+    const deviceWavePeriod = props.signalArray !== "" ? JSON.parse(props.signalArray)["Wave Period"] : wave_period;
+    if (deviceAmplitude !== "" && deviceWavePeriod !== "") {
+        for (let i = 0; i < parseFloat(props.arrayLength); i++) {
+            let currData = parseFloat(deviceAmplitude) * Math.sign(Math.sin((2 * Math.PI * (i * (parseFloat(props.telemetrySendInterval) / 1000))) / (parseFloat(deviceWavePeriod) / 1000)));
+            ar.push(currData);
+        }
+        if (props.signalArray === "") {
+            const squareObj = `{"Behaviour":"Square","Amplitude":${deviceAmplitude},"Wave Period":${deviceWavePeriod}}`;
+            props.setCurrDataArray(ar, squareObj);
+        }
+    }
+    return (
+        <>
+            <div className="behaviour-value">
+                <LabeledInput className="labels" type='number' label='Amplitude' name='amplitude' value={deviceAmplitude} onChange={changeAmplitude} disabled={props.signalArray !== "" ? true : false} />
+                <LabeledInput className="labels" type='number' label='Period(ms)' name='wave_period' value={deviceWavePeriod} onChange={changeWave_period} disabled={props.signalArray !== "" ? true : false} />
+            </div>
+            <ChartComponent labelsArray={arr} dataArray={ar} chartName="Component Signal" />
+        </>
+    );
+
+}
+
+export function BehaviourComponent(props) {
+    // const signalArray=`{"Behaviour":"Sine","Mean":100,"Amplitude":10, "Wave Period":20000}`    
+    return (
+        <div className="behaviour-prop">
+            {
+                props.behaviour === "Sine" ?
+                    <SineComponent arrayLength={props.arrayLength} telemetrySendInterval={props.telemetrySendInterval} signalArray={props.signalArray} setCurrDataArray={props.setCurrDataArray} />
+                : props.behaviour === "Constant" ?
+                    <ConstantComponent arrayLength={props.arrayLength} telemetrySendInterval={props.telemetrySendInterval} signalArray={props.signalArray} setCurrDataArray={props.setCurrDataArray} />
+                : props.behaviour === "Linear" ?
+                    <LinearComponent arrayLength={props.arrayLength} telemetrySendInterval={props.telemetrySendInterval} signalArray={props.signalArray} setCurrDataArray={props.setCurrDataArray} />
+                : props.behaviour === "Noise" ?
+                    <NoiseComponent arrayLength={props.arrayLength} telemetrySendInterval={props.telemetrySendInterval} signalArray={props.signalArray} setCurrDataArray={props.setCurrDataArray} />
+                : props.behaviour === "Triangular" ?
+                    <TriangularComponent arrayLength={props.arrayLength} telemetrySendInterval={props.telemetrySendInterval} signalArray={props.signalArray} setCurrDataArray={props.setCurrDataArray} />
+                : props.behaviour === "Sawtooth" ?
+                    <SawToothComponent arrayLength={props.arrayLength} telemetrySendInterval={props.telemetrySendInterval} signalArray={props.signalArray} setCurrDataArray={props.setCurrDataArray} />
+                : props.behaviour === "Square" ?
+                    <SquareComponent arrayLength={props.arrayLength} telemetrySendInterval={props.telemetrySendInterval} signalArray={props.signalArray} setCurrDataArray={props.setCurrDataArray} />
+                : null
+            }
+        </div>
+
+    );
+
+}

--- a/IoTDeviceSimulator/web-client/src/ChartComponent.js
+++ b/IoTDeviceSimulator/web-client/src/ChartComponent.js
@@ -1,7 +1,6 @@
 import { Line } from 'react-chartjs-2';
 
 export function ChartComponent(props) {  
-    console.log("Inside chart Component");
     return (
         <div className="preview">
             <Line

--- a/IoTDeviceSimulator/web-client/src/ChartComponent.js
+++ b/IoTDeviceSimulator/web-client/src/ChartComponent.js
@@ -1,0 +1,51 @@
+import { Line } from 'react-chartjs-2';
+
+export function ChartComponent(props) {  
+    console.log("Inside chart Component");
+    return (
+        <div className="preview">
+            <Line
+                data={{
+                    labels: props.labelsArray,
+                    datasets: [
+                        {
+                            label: props.chartName,
+                            data: props.dataArray,
+                            fill: false,
+                            borderColor: "rgb(0,139,225)",
+                            borderWidth: 2,
+                            pointRadius: 0,
+                        },
+                    ],
+                }}
+                options={{
+                    maintainAspectRatio: true,
+                    scales: {
+                        yAxes: [
+                            {
+                                ticks: {
+                                    beginAtZero: true,
+                                },
+                            },
+                        ],
+                        xAxes: [
+                            {
+                                scaleLabel: {
+                                    display: true,
+                                    labelString: 'Time (second)',
+                                    fontColor: "rgb(0,139,225)"
+                                }
+                            }
+                        ]
+                    },
+                    legend: {
+                        labels: {
+                            fontSize: 15,
+                            fontColor: "rgb(0,139,225)",
+                        },
+                    },
+                }}
+            />
+        </div>
+    );
+}

--- a/IoTDeviceSimulator/web-client/src/DeviceTwin.js
+++ b/IoTDeviceSimulator/web-client/src/DeviceTwin.js
@@ -279,7 +279,7 @@ export function DeviceTwin(props) {
     
     const sineInfo = "A sinusoidal wave is a mathematical curve defined in terms of the sine trigonometric function, of which it is the graph.";
     const constantInfo = "A constant wave is a wave that is same everywhere & having the same value of range for different values of the domain.";
-    const increasingInfo = "A stricty increasing wave is a wave in which Y-value increases with the increasing value on X-axis.";
+    const increasingInfo = "A strictly increasing wave is a wave in which Y-value increases with the increasing value on X-axis.";
     const noiseInfo = "A noise wave is an unwanted random disturbance of a signal.";
     const triangularInfo = "A triangular wave or triangle wave is a non-sinusoidal waveform named for its triangular shape.";
     const sawtoothInfo = "The sawtooth wave is a kind of non-sinusoidal waveform named for its resemblance to the teeth of a plain-toothed saw with a zero rake angle.";
@@ -288,14 +288,14 @@ export function DeviceTwin(props) {
     const getContent = () => {
         if (deviceTwin.signalArray[index] === "") {
             return (<div className="behaviour-func">
-                <div className="behaviour-list">
-                    <Select value={behaviour} placeholder={"Select Behaviour"} options={options} onChange={changeBehaviour} style={{ width: "300px" }} itemRenderer={(option) => (
-                        < MenuItem><Tooltip placement="right" content={option.value === 'Sine' ? sineInfo : option.value === 'Constant' ? constantInfo : option.value === 'Linear' ? increasingInfo : option.value === 'Noise' ? noiseInfo : option.value === 'Triangular' ? triangularInfo : option.value === 'Sawtooth' ? sawtoothInfo : squareInfo}><div className="option">{option.label}</div></Tooltip></MenuItem>
-                    )} >
-                    </Select>
-                </div>
-                <BehaviourComponent behaviour={behaviour} signalArray="" telemetrySendInterval={deviceTwin.telemetrySendInterval} arrayLength={len} setCurrDataArray={setCurrDataArray} newBehaviour={newBehaviour}/>
-            </div >);
+                        <div className="behaviour-list">
+                            <Select value={behaviour} placeholder={"Select Behaviour"} options={options} onChange={changeBehaviour} style={{ width: "300px" }} itemRenderer={(option) => (
+                                < MenuItem><Tooltip placement="right" content={option.value === 'Sine' ? sineInfo : option.value === 'Constant' ? constantInfo : option.value === 'Linear' ? increasingInfo : option.value === 'Noise' ? noiseInfo : option.value === 'Triangular' ? triangularInfo : option.value === 'Sawtooth' ? sawtoothInfo : squareInfo}><div className="option">{option.label}</div></Tooltip></MenuItem>
+                            )} >
+                            </Select>
+                        </div>
+                        <BehaviourComponent behaviour={behaviour} signalArray="" telemetrySendInterval={deviceTwin.telemetrySendInterval} arrayLength={len} setCurrDataArray={setCurrDataArray} newBehaviour={newBehaviour} isAdmin={props.isAdmin}/>
+                    </div >);
         }
         else {            
             if (deviceTwin.signalArray[index] === undefined) {
@@ -303,16 +303,15 @@ export function DeviceTwin(props) {
             }
             else {            
                 return (<div>
-                    <div className="behaviour-list">
-                        <Select value={JSON.parse(deviceTwin.signalArray[index])["Behaviour"]} options={options} style={{ width: "300px" }} disabled={true}></Select>
-                    </div>
-                    <BehaviourComponent behaviour={JSON.parse(deviceTwin.signalArray[index])["Behaviour"]} signalArray={deviceTwin.signalArray[index]} telemetrySendInterval={deviceTwin.telemetrySendInterval} arrayLength={len} setCurrDataArray={setCurrDataArray} newBehaviour={newBehaviour}/>
-                </div>);
+                            <div className="behaviour-list">
+                                <Select value={JSON.parse(deviceTwin.signalArray[index])["Behaviour"]} options={options} style={{ width: "300px" }} disabled={true}></Select>
+                            </div>
+                            <BehaviourComponent behaviour={JSON.parse(deviceTwin.signalArray[index])["Behaviour"]} signalArray={deviceTwin.signalArray[index]} telemetrySendInterval={deviceTwin.telemetrySendInterval} arrayLength={len} setCurrDataArray={setCurrDataArray} newBehaviour={newBehaviour} isAdmin={props.isAdmin}/>
+                        </div>);
             }
         }
-    };    
-     
-
+    };   
+    
     return (
         <>
             <Modal
@@ -336,13 +335,13 @@ export function DeviceTwin(props) {
                             </div>
                             <div className="behaviour-area">
                                 <InputGroup label='No. of datapoints' displayStyle="inline">
-                                    <Radio name="choice" value={10} label={'10'} onChange={handleLength} checked={parseFloat(len) === 10?true:false}/>
-                                    <Radio name="choice" value={50} label={'50'} onChange={handleLength} checked={parseFloat(len) === 50?true:false}/>
-                                    <Radio name="choice" value={100} label={'100'} onChange={handleLength} checked={parseFloat(len) === 100?true:false}/>
+                                    <Radio name="choice" value={10} label={'10'} onChange={handleLength} checked={parseFloat(len) === 10 ? true : false} />
+                                    <Radio name="choice" value={50} label={'50'} onChange={handleLength} checked={parseFloat(len) === 50 ? true : false} />
+                                    <Radio name="choice" value={100} label={'100'} onChange={handleLength} checked={parseFloat(len) === 100 ? true : false} />
                                 </InputGroup>
 
-                                <ChartComponent labelsArray={arr} dataArray={currDataArray} chartName="Composite Signal"/>
-                                
+                                <ChartComponent labelsArray={arr} dataArray={currDataArray} chartName="Composite Signal" />
+
                                 {deviceTwin.signalArray && !deviceTwin.valueIsBool ?
                                     <HorizontalTabs
                                         style={{ overflow: "scroll", width: "400px" }}
@@ -366,75 +365,60 @@ export function DeviceTwin(props) {
                         {deviceTwin.deviceAction === DeviceAction.ADD ?
                             <Button className="buttons" styleType="high-visibility" onClick={addDevice}> Add </Button> : <Button className="buttons" styleType="high-visibility" onClick={updateDeviceTwin}  > Update </Button>}
                     </div>
-                    : <table>
-                        <tr>
-                            <td className="tableLabelStyle"><Label>Device Id</Label></td>
-                            <td className="tableStyle"><Label>{deviceTwin.deviceId}</Label></td>
-                        </tr>
-                        <tr>
-                            <td className="tableLabelStyle"><Label>Device Name</Label></td>
-                            <td className="tableStyle"><Label>{deviceTwin.deviceName}</Label></td>
-                        </tr>
-                        <tr>
-                            <td className="tableLabelStyle"><Label>Phenomenon</Label></td>
-                            <td className="tableStyle"><Label>{deviceTwin.phenomenon}</Label></td>
-                        </tr>
-                        {deviceTwin.unit ?
+                    :
+                    <div style={{width:"500px"}}>
+                        <table>
                             <tr>
-                                <td className="tableLabelStyle"><Label>Unit</Label></td>
-                                <td className="tableStyle"><Label>{deviceTwin.unit}</Label></td>
-                            </tr> : <></>}
-                        {deviceTwin.valueIsBool ?
+                                <td className="titleStyle" colSpan="100%"><Label>Properties</Label></td>
+                            </tr>
                             <tr>
-                                <td className="tableLabelStyle"><Label>Is value bool</Label></td>
-                                <td className="tableStyle"><Label>{deviceTwin.valueIsBool.toString()}</Label></td>
-                            </tr> : <></>}
-                        {deviceTwin.behaviour ?
-                            <>
+                                <td className="tableLabelStyle"><Label>Device Id</Label></td>
+                                <td className="tableStyle"><Label>{deviceTwin.deviceId}</Label></td>
+                            </tr>
+                            <tr>
+                                <td className="tableLabelStyle"><Label>Device Name</Label></td>
+                                <td className="tableStyle"><Label>{deviceTwin.deviceName}</Label></td>
+                            </tr>
+                            <tr>
+                                <td className="tableLabelStyle"><Label>Phenomenon</Label></td>
+                                <td className="tableStyle"><Label>{deviceTwin.phenomenon}</Label></td>
+                            </tr>
+                            {deviceTwin.unit ?
                                 <tr>
-                                    <td className="tableLabelStyle"><Label>Behaviour</Label></td>
-                                    <td className="tableStyle"><Label>{deviceTwin.behaviour}</Label></td>
-                                </tr>
-                                {deviceTwin.behaviour === "Sine" ?
-                                    <>
-                                        <tr>
-                                            <td className="tableLabelStyle"><Label>Mean</Label></td>
-                                            <td className="tableStyle"><Label>{deviceTwin.mean}</Label></td>
-                                        </tr>
-                                        <tr>
-                                            <td className="tableLabelStyle"><Label>Amplitude</Label></td>
-                                            <td className="tableStyle"><Label>{deviceTwin.amplitude}</Label></td>
-                                        </tr>
-                                        <tr>
-                                            <td className="tableLabelStyle"><Label>Wave Period(ms)</Label></td>
-                                            <td className="tableStyle"><Label>{deviceTwin.wave_period}</Label></td>
-                                        </tr>
-                                    </> : deviceTwin.behaviour === "Constant" ?
-                                        <>
-                                            <tr>
-                                                <td className="tableLabelStyle"><Label>Mean</Label></td>
-                                                <td className="tableStyle"><Label>{deviceTwin.mean}</Label></td>
-                                            </tr>
-                                        </> :
-                                        <>
-                                            <tr>
-                                                <td className="tableLabelStyle"><Label>Slope</Label></td>
-                                                <td className="tableStyle"><Label>{deviceTwin.slope}</Label></td>
-                                            </tr>
-                                        </>
-                                }
+                                    <td className="tableLabelStyle"><Label>Unit</Label></td>
+                                    <td className="tableStyle"><Label>{deviceTwin.unit}</Label></td>
+                                </tr> : <></>}
+                            {deviceTwin.valueIsBool ?
                                 <tr>
-                                    <td className="tableLabelStyle"><Label>Noise Magnitude</Label></td>
-                                    <td className="tableStyle"><Label>{deviceTwin.noise_magnitude}</Label></td>
-                                </tr>
-                            </>
-                            : <></>
+                                    <td className="tableLabelStyle"><Label>Is value bool</Label></td>
+                                    <td className="tableStyle"><Label>{deviceTwin.valueIsBool.toString()}</Label></td>
+                                </tr> : <></>}
+                            <tr>
+                                <td className="tableLabelStyle"><Label>Period (ms)</Label></td>
+                                <td className="tableStyle"><Label>{deviceTwin.telemetrySendInterval}</Label></td>
+                            </tr>
+                        </table>
+                        
+                        {deviceTwin.signalArray?  
+                         <>       
+                            <table className="scrollBarStyle">
+                                <thead>
+                                    <tr id="Header" >
+                                        <td className="titleStyle"><Label>Behaviour</Label></td>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {deviceTwin.signalArray.map((type,index) => {
+                                        return(
+                                            <BehaviourComponent key={index} behaviour={JSON.parse(type)["Behaviour"]} signalArray={type} telemetrySendInterval={deviceTwin.telemetrySendInterval} arrayLength={len} setCurrDataArray={setCurrDataArray} newBehaviour = {props.newBehaviour} isAdmin={props.isAdmin}/>
+                                        )
+                                    })} 
+                                </tbody>
+                            </table>
+                         </> 
+                        : <></>
                         }
-                        <tr>
-                            <td className="tableLabelStyle"><Label>Period (ms)</Label></td>
-                            <td className="tableStyle"><Label>{deviceTwin.telemetrySendInterval}</Label></td>
-                        </tr>
-                    </table>
+                    </div>
                 }
             </Modal >
         </>

--- a/IoTDeviceSimulator/web-client/src/DeviceTwin.js
+++ b/IoTDeviceSimulator/web-client/src/DeviceTwin.js
@@ -146,7 +146,8 @@ export function DeviceTwin(props) {
         }
     }, [deviceTwin, props, url]);
 
-    const onClose = useCallback(() => {               
+    const onClose = useCallback(() => {  
+        setNewBehaviour("");             
         props.handleClose();
     }, [props]);
 
@@ -293,7 +294,7 @@ export function DeviceTwin(props) {
                     )} >
                     </Select>
                 </div>
-                <BehaviourComponent behaviour={behaviour} signalArray="" telemetrySendInterval={deviceTwin.telemetrySendInterval} arrayLength={len} setCurrDataArray={setCurrDataArray}/>
+                <BehaviourComponent behaviour={behaviour} signalArray="" telemetrySendInterval={deviceTwin.telemetrySendInterval} arrayLength={len} setCurrDataArray={setCurrDataArray} newBehaviour={newBehaviour}/>
             </div >);
         }
         else {            
@@ -305,7 +306,7 @@ export function DeviceTwin(props) {
                     <div className="behaviour-list">
                         <Select value={JSON.parse(deviceTwin.signalArray[index])["Behaviour"]} options={options} style={{ width: "300px" }} disabled={true}></Select>
                     </div>
-                    <BehaviourComponent behaviour={JSON.parse(deviceTwin.signalArray[index])["Behaviour"]} signalArray={deviceTwin.signalArray[index]} telemetrySendInterval={deviceTwin.telemetrySendInterval} arrayLength={len} setCurrDataArray={setCurrDataArray}/>
+                    <BehaviourComponent behaviour={JSON.parse(deviceTwin.signalArray[index])["Behaviour"]} signalArray={deviceTwin.signalArray[index]} telemetrySendInterval={deviceTwin.telemetrySendInterval} arrayLength={len} setCurrDataArray={setCurrDataArray} newBehaviour={newBehaviour}/>
                 </div>);
             }
         }

--- a/IoTDeviceSimulator/web-client/src/DeviceTwin.js
+++ b/IoTDeviceSimulator/web-client/src/DeviceTwin.js
@@ -6,61 +6,59 @@
 import React, { useCallback, useEffect, useState, useMemo } from "react";
 import { Modal, LabeledInput, ToggleSwitch, toaster, Button, Label, Select, HorizontalTabs, Tab, InputGroup, Radio, MenuItem, Tooltip } from "@itwin/itwinui-react";
 import { DeviceAction } from "./Utils";
-import { Line } from 'react-chartjs-2'
 import { editDeviceTwins, getHeaders } from "./AzureUtilities";
 import { editAWSThings } from "./AWSUtililities";
+import { ChartComponent } from "./ChartComponent";
+import { BehaviourComponent } from "./BehaviourComponent";
 
-let ar = [];
 let arr = [];
-let currDataArray = [];
+export let currDataArray = [];
 
 export function DeviceTwin(props) {
     const [deviceTwin, setDeviceTwin] = useState({
-        deviceAction: props.device.deviceAction,
-        deviceId: props.device.deviceId,
-        deviceName: props.device.deviceName,
-        phenomenon: props.device.phenomenon,
-        unit: props.device.unit,
-        valueIsBool: props.device.valueIsBool,
-        telemetrySendInterval: props.device.telemetrySendInterval,
-        noiseSd: props.device.noiseSd,
-        isRunning: props.device.isRunning,
-        min: props.device.min,
-        max: props.device.max,
-        thingTypeName: props.device.thingTypeName,
-        signalArray: props.device.signalArray,
+        deviceAction: props.device.deviceAction!==undefined ? JSON.parse(JSON.stringify(props.device.deviceAction)):"",
+        deviceId: props.device.deviceId!==undefined ? JSON.parse(JSON.stringify(props.device.deviceId)) :"" ,
+        deviceName: props.device.deviceName!==undefined ? JSON.parse(JSON.stringify(props.device.deviceName)) :"",
+        unit: props.device.unit!==undefined? JSON.parse(JSON.stringify(props.device.unit)):"" ,
+        phenomenon: props.device.phenomenon!==undefined ? JSON.parse(JSON.stringify(props.device.phenomenon)) :"",
+        valueIsBool: props.device.valueIsBool!==undefined? JSON.parse(JSON.stringify(props.device.valueIsBool)):false ,
+        telemetrySendInterval: props.device.telemetrySendInterval!==undefined ? JSON.parse(JSON.stringify(props.device.telemetrySendInterval)) :"" ,
+        noiseSd: 0.45,
+        isRunning: props.device.isRunning!==undefined ? JSON.parse(JSON.stringify(props.device.isRunning)) : false ,
+        min: props.device.min!==undefined ? JSON.parse(JSON.stringify(props.device.min)):"",
+        max: props.device.max!==undefined ? JSON.parse(JSON.stringify(props.device.max)) :"" ,
+        thingTypeName: props.device.thingTypeName!==undefined ? JSON.parse(JSON.stringify(props.device.thingTypeName)) :"" ,
+        signalArray: props.device.signalArray!==undefined ? JSON.parse(JSON.stringify(props.device.signalArray)) :"" ,
+    
     });
-
-    const [mean, setMean] = useState("");
-    const [amplitude, setAmplitude] = useState("");
-    const [wave_period, setWave_period] = useState("");
-    const [noise_magnitude, setNoise_magnitude] = useState("");
-    const [slope, setSlope] = useState("");
-    const [behaviour, setBehaviour] = useState("Noise");
+    
+    const [behaviour, setBehaviour] = useState("");
     const [index, setIndex] = useState(0);
-    const [len, setLen] = useState(0);
+    const [len, setLen] = useState(50);
     const [tabCount, setTabCount] = useState(0)
+    const [compositeSignalDataArrayChanged, setCompositeSignalDataArrayChanged]=useState(false);
+    const [newBehaviour, setNewBehaviour]=useState("");
     const url = useMemo(() => process.env.REACT_APP_FUNCTION_URL, []);
 
     useEffect(() => {
         setDeviceTwin({
-            deviceAction: props.device.deviceAction,
-            deviceId: props.device.deviceId ?? '',
-            deviceName: props.device.deviceName ?? '',
-            unit: props.device.unit ?? '',
-            phenomenon: props.device.phenomenon ?? '',
-            valueIsBool: props.device.valueIsBool ?? false,
-            telemetrySendInterval: props.device.telemetrySendInterval ?? '',
+            deviceAction: props.device.deviceAction!==undefined ? JSON.parse(JSON.stringify(props.device.deviceAction)):"",
+            deviceId: props.device.deviceId!==undefined ? JSON.parse(JSON.stringify(props.device.deviceId)) :"" ,
+            deviceName: props.device.deviceName!==undefined ? JSON.parse(JSON.stringify(props.device.deviceName)) :"",
+            unit: props.device.unit!==undefined? JSON.parse(JSON.stringify(props.device.unit)):"" ,
+            phenomenon: props.device.phenomenon!==undefined ? JSON.parse(JSON.stringify(props.device.phenomenon)) :"",
+            valueIsBool: props.device.valueIsBool!==undefined? JSON.parse(JSON.stringify(props.device.valueIsBool)):false ,
+            telemetrySendInterval: props.device.telemetrySendInterval!==undefined ? JSON.parse(JSON.stringify(props.device.telemetrySendInterval)) :"" ,
             noiseSd: 0.45,
-            isRunning: props.device.isRunning ?? false,
-            min: props.device.min ?? '',
-            max: props.device.max ?? '',
-            thingTypeName: props.device.thingTypeName ?? '',
-            signalArray: props.device.signalArray ?? [`{"Behaviour":"Constant","Mean":100}`, `{"Behaviour":"Noise","Noise Magnitude":5,"Noise Standard-deviation":0.45}`],
-        });
+            isRunning: props.device.isRunning!==undefined ? JSON.parse(JSON.stringify(props.device.isRunning)) : false ,
+            min: props.device.min!==undefined ? JSON.parse(JSON.stringify(props.device.min)):"",
+            max: props.device.max!==undefined ? JSON.parse(JSON.stringify(props.device.max)) :"" ,
+            thingTypeName: props.device.thingTypeName!==undefined ? JSON.parse(JSON.stringify(props.device.thingTypeName)) :"" ,
+            signalArray: props.device.signalArray!==undefined ? JSON.parse(JSON.stringify(props.device.signalArray)) : [`{"Behaviour":"Constant","Mean":100}`, `{"Behaviour":"Noise","Noise Magnitude":5,"Noise Standard-deviation":0.45}`],
+        });                
         setTabCount(props.device.signalArray?.length ?? 2);
     }, [props]);
-
+   
     const handleChange = useCallback((event) => {
         event.preventDefault();
         setDeviceTwin({
@@ -68,26 +66,7 @@ export function DeviceTwin(props) {
             [event.target.name]: event.target.value,
         });
     }, [deviceTwin]);
-
-    const changeMean = (event) => {
-        setMean(event.target.value);
-    }
-
-    const changeAmplitude = (event) => {
-        setAmplitude(event.target.value);
-    }
-
-    const changeWave_period = (event) => {
-        setWave_period(event.target.value);
-    }
-
-    const changeNoise_magnitude = (event) => {
-        setNoise_magnitude(event.target.value);
-    }
-
-    const changeSlope = (event) => {
-        setSlope(event.target.value);
-    }
+    
 
     const changeBehaviour = (event) => {
         setBehaviour(event);
@@ -95,57 +74,23 @@ export function DeviceTwin(props) {
 
     const setBehaviourConfigurer = () => {
         let k = 0;
+        const deviceSignalArray= deviceTwin.signalArray;
         if (deviceTwin.signalArray[deviceTwin.signalArray.length - 1] === '') {
             k = 1;
-            deviceTwin.signalArray.pop();
+            deviceSignalArray.pop();
         }
-        if (behaviour === 'Sine' && mean !== '' && amplitude !== '' && wave_period !== '') {
-            const sineObj = `{"Behaviour":"Sine","Mean":${mean},"Amplitude":${amplitude},"Wave Period":${wave_period},"Phase":"0"}`;
-            deviceTwin.signalArray.push(sineObj);
-            setMean("");
-            setAmplitude("");
-            setWave_period("");
+                
+        if (k===1 && newBehaviour==="") {
+            toaster.negative(`Required values are not provided!`);
+        }else if(newBehaviour!=="")
+        {
+            deviceSignalArray.push(newBehaviour);
+            setNewBehaviour("");
         }
-        else if (behaviour === 'Constant' && mean !== '') {
-            const constObj = `{"Behaviour":"Constant","Mean":${mean}}`;
-            deviceTwin.signalArray.push(constObj);
-            setMean("");
-        }
-        else if (behaviour === 'Linear' && slope !== '') {
-            const increasingObj = `{"Behaviour":"Linear","Slope":${slope}}`;
-            deviceTwin.signalArray.push(increasingObj);
-            setSlope("");
-        }
-        else if (behaviour === 'Noise' && noise_magnitude !== '') {
-            const noiseObj = `{"Behaviour":"Noise","Noise Magnitude":${noise_magnitude},"Noise Standard-deviation":${deviceTwin.noiseSd}}`;
-            deviceTwin.signalArray.push(noiseObj);
-            setNoise_magnitude("");
-        }
-        else if (behaviour === 'Triangular' && amplitude !== '' && wave_period !== '') {
-            const triangularObj = `{"Behaviour":"Triangular","Amplitude":${amplitude},"Wave Period":${wave_period}}`;
-            deviceTwin.signalArray.push(triangularObj);
-            setAmplitude("");
-            setWave_period("");
-        }
-        else if (behaviour === 'Sawtooth' && amplitude !== '' && wave_period !== '') {
-            const sawtoothObj = `{"Behaviour":"Sawtooth","Amplitude":${amplitude},"Wave Period":${wave_period}}`;
-            deviceTwin.signalArray.push(sawtoothObj);
-            setAmplitude("");
-            setWave_period("");
-        }
-        else if (behaviour === 'Square' && amplitude !== '' && wave_period !== '') {
-            const squareObj = `{"Behaviour":"Square","Amplitude":${amplitude},"Wave Period":${wave_period}}`;
-            deviceTwin.signalArray.push(squareObj);
-            setAmplitude("");
-            setWave_period("");
-        }
-        else {
-            if (k === 1) {
-                toaster.negative(`Required values are not provided!`);
-            }
-        }
-        setTabCount(deviceTwin.signalArray.length + 1);
-        deviceTwin.signalArray.push("");
+        
+        setTabCount(deviceTwin.signalArray.length+1);
+        deviceSignalArray.push("");
+        setDeviceTwin({...deviceTwin,signalArray:deviceSignalArray});
         setBehaviour("");
     }
 
@@ -160,13 +105,16 @@ export function DeviceTwin(props) {
             deviceTwin.signalArray.pop();
         }
         if (props.connection.includes("Azure")) {
+            if (deviceTwin.signalArray[deviceTwin.signalArray.length - 1] === "") {
+                deviceTwin.signalArray.pop();
+            }
             let deviceArray = [deviceTwin];
             const response = await editDeviceTwins(deviceArray, props.connectionStringId)
             updatedDevice = response.updated;
+            
         } else {
             updatedDevice = await editAWSThings([deviceTwin]);
-        }
-
+        }        
         if (updatedDevice) {
             toaster.informational(`Updated device twin : ${deviceTwin.deviceId}`);
             props.handleClose(deviceTwin);
@@ -181,7 +129,7 @@ export function DeviceTwin(props) {
             headers: getHeaders(),
             body: JSON.stringify(data),
         }).catch(error => console.log("Request failed: " + error));
-        if (response && response.status === 200) {
+        if (response && response.status === 200) {            
             if (deviceTwin.signalArray[deviceTwin.signalArray.length - 1] === "") {
                 deviceTwin.signalArray.pop();
             }
@@ -197,7 +145,7 @@ export function DeviceTwin(props) {
         }
     }, [deviceTwin, props, url]);
 
-    const onClose = useCallback(() => {
+    const onClose = useCallback(() => {               
         props.handleClose();
     }, [props]);
 
@@ -213,81 +161,43 @@ export function DeviceTwin(props) {
 
     const removeBehaviour = (i) => {
         let k = 0;
+        const deviceSignalArray=deviceTwin.signalArray;
         for (let i = 0; i < deviceTwin.signalArray.length; i++) {
             if (deviceTwin.signalArray[i] !== '') {
                 k += 1;
             }
         }
         if (k === 1 && i === 0) {
-            toaster.negative(`There should be atleast one behaviour`)
+            toaster.negative(`Behaviour cannot be empty!`)
         }
         else {
-            setTabCount(deviceTwin.signalArray.length - 1);
-            deviceTwin.signalArray.splice(i, 1);
+            
+            deviceSignalArray.splice(i, 1);                      
+            setTabCount(deviceSignalArray.length);
+            setDeviceTwin({...deviceTwin,signalArray:deviceSignalArray});
+            setBehaviour("");
+            setNewBehaviour("");
         }
-    }
-
-    ar = [];
+    }       
     arr = [];
 
     for (let i = 0; i < len; i++) {
         arr.push(i * (deviceTwin.telemetrySendInterval) / 1000);
-    }
+    } 
+    
+    useEffect(()=>{
+        currDataArray=[];
+        for(let i=0;i<len;i++)
+        {
+            currDataArray[i]=0;
+        }
+        getCompositeSignalDataArray();
+        setCompositeSignalDataArrayChanged(!compositeSignalDataArrayChanged);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    },[deviceTwin,len]);
 
-    if (behaviour === 'Sine') {
-        const phase = 0;
-        for (let i = 0; i < len; i++) {
-            let currData = parseFloat(mean) + Math.sin((i * (parseFloat(deviceTwin.telemetrySendInterval) / 1000)) * (2 * Math.PI) / (parseFloat(wave_period) / 1000) + phase) * parseFloat(amplitude);
-            ar.push(currData);
-        }
-    }
-    else if (behaviour === 'Constant') {
-        for (let i = 0; i < len; i++) {
-            let currData = parseFloat(mean);
-            ar.push(currData);
-        }
-    }
-    else if (behaviour === 'Linear') {
-        for (let i = 0; i < len; i++) {
-            let currData = parseFloat(slope) * ((i * (parseFloat(deviceTwin.telemetrySendInterval) / 1000)));
-            ar.push(currData);
-        }
-    }
-    else if (behaviour === 'Noise') {
-        let mean = 0;
-        let standard_deviation = parseFloat(deviceTwin.noiseSd);
-        for (let i = 0; i < len; i++) {
-            let x = (Math.random() - 0.5) * 2;
-            let noise = (1 / (Math.sqrt(2 * Math.PI) * standard_deviation)) * Math.pow(Math.E, -1 * Math.pow((x - mean) / standard_deviation, 2) / 2);
-            let noise_mag = noise_magnitude * Math.sign((Math.random() - 0.5) * 2);
-            let currData = noise * noise_mag;
-            ar.push(currData);
-        }
-    }
-    else if (behaviour === 'Triangular') {
-        for (let i = 0; i < len; i++) {
-            let currData = (2 * parseFloat(amplitude) * Math.asin(Math.sin((2 * Math.PI * (i * (parseFloat(deviceTwin.telemetrySendInterval) / 1000))) / (parseFloat(wave_period) / 1000)))) / Math.PI;
-            ar.push(currData);
-        }
-    }
-    else if (behaviour === 'Sawtooth') {
-        for (let i = 0; i < len; i++) {
-            let currData = 2 * parseFloat(amplitude) * ((i * (parseFloat(deviceTwin.telemetrySendInterval) / 1000)) / (parseFloat(wave_period) / 1000) - Math.floor(1 / 2 + (i * (parseFloat(deviceTwin.telemetrySendInterval) / 1000)) / (parseFloat(wave_period) / 1000)));
-            ar.push(currData);
-        }
-    }
-    else if (behaviour === 'Square') {
-        for (let i = 0; i < len; i++) {
-            let currData = parseFloat(amplitude) * Math.sign(Math.sin((2 * Math.PI * (i * (parseFloat(deviceTwin.telemetrySendInterval) / 1000))) / (parseFloat(wave_period) / 1000)));
-            ar.push(currData);
-        }
-    }
-
-    if (deviceTwin.signalArray && !deviceTwin.valueIsBool) {
-        currDataArray = [];
-        for (let i = 0; i < len; i++) {
-            currDataArray[i] = (ar[i] ? ar[i] : 0);
-        }
+    const getCompositeSignalDataArray=()=>{
+        if(deviceTwin.signalArray===undefined)return [];
         for (let i = 0; i < deviceTwin.signalArray.length; i++) {
             if (deviceTwin.signalArray[i] !== '') {
                 if (JSON.parse(deviceTwin.signalArray[i])["Behaviour"] === "Sine") {
@@ -321,8 +231,7 @@ export function DeviceTwin(props) {
                 }
                 else if (JSON.parse(deviceTwin.signalArray[i])["Behaviour"] === "Triangular") {
                     for (let j = 0; j < len; j++) {
-                        let currData = (2 * parseFloat(JSON.parse(deviceTwin.signalArray[i])["Amplitude"]) * Math.asin(Math.sin((2 * Math.PI * (j * (parseFloat(deviceTwin.telemetrySendInterval) / 1000))) / (parseFloat(JSON.parse(deviceTwin.signalArray[i])["Wave Period"]) / 1000)))) / Math.PI;
-                        ar.push(currData);
+                        let currData = (2 * parseFloat(JSON.parse(deviceTwin.signalArray[i])["Amplitude"]) * Math.asin(Math.sin((2 * Math.PI * (j * (parseFloat(deviceTwin.telemetrySendInterval) / 1000))) / (parseFloat(JSON.parse(deviceTwin.signalArray[i])["Wave Period"]) / 1000)))) / Math.PI;                        
                         currDataArray[j] += currData;
                     }
                 }
@@ -344,9 +253,20 @@ export function DeviceTwin(props) {
                     currDataArray[j] += 0;
                 }
             }
-        }
+        }        
     }
-
+  
+    const setCurrDataArray=(behaviourDataArray, behaviourObject)=>{        
+        if (deviceTwin.signalArray && !deviceTwin.valueIsBool) {
+            currDataArray = [];
+            for (let i = 0; i < len; i++) {
+                currDataArray[i] = (behaviourDataArray[i] ? behaviourDataArray[i] : 0);
+            }
+            getCompositeSignalDataArray();            
+        }
+        setNewBehaviour(behaviourObject);                
+    }
+                
     if (deviceTwin.valueIsBool) {
         currDataArray = [];
         for (let i = 0; i < len; i++) {
@@ -354,7 +274,7 @@ export function DeviceTwin(props) {
             currDataArray.push(currData);
         }
     }
-
+    
     const sineInfo = "A sinusoidal wave is a mathematical curve defined in terms of the sine trigonometric function, of which it is the graph.";
     const constantInfo = "A constant wave is a wave that is same everywhere & having the same value of range for different values of the domain.";
     const increasingInfo = "A stricty increasing wave is a wave in which Y-value increases with the increasing value on X-axis.";
@@ -372,232 +292,24 @@ export function DeviceTwin(props) {
                     )} >
                     </Select>
                 </div>
-                <div className="behaviour-prop">
-                    {
-                        behaviour === "Sine" ?
-                            <div className="behaviour-value">
-                                <LabeledInput className="labels" type='number' label='Mean' name='mean' value={mean} onChange={changeMean} />
-                                <LabeledInput className="labels" type='number' label='Amplitude' name='amplitude' value={amplitude} onChange={changeAmplitude} />
-                                <LabeledInput className="labels" type='number' label='Period(ms)' name='wave_period' value={wave_period} onChange={changeWave_period} />
-                            </div >
-                            : behaviour === "Constant" ?
-                                <div className="behaviour-value">
-                                    <LabeledInput className="labels" type='number' label='Mean' name='mean' value={mean} onChange={changeMean} />
-                                </div>
-                                : behaviour === "Linear" ?
-                                    <div className="behaviour-value">
-                                        <LabeledInput className="labels" type='number' label='Slope' name='slope' value={slope} onChange={changeSlope} />
-                                    </div>
-                                    : behaviour === "Noise" ?
-                                        <div className="behaviour-value">
-                                            <LabeledInput className="labels" type='number' label='Magnitude' name='noise_magnitude' value={noise_magnitude} onChange={changeNoise_magnitude} />
-                                            <LabeledInput className="labels" type='number' label='Deviation' name='noiseSd' value={0.45} disabled={true} />
-                                        </div>
-                                        : behaviour === "Triangular" ?
-                                            <div className="behaviour-value">
-                                                <LabeledInput className="labels" type='number' label='Amplitude' name='amplitude' value={amplitude} onChange={changeAmplitude} />
-                                                <LabeledInput className="labels" type='number' label='Period(ms)' name='wave_period' value={wave_period} onChange={changeWave_period} />
-                                            </div>
-                                            : behaviour === "Sawtooth" ?
-                                                <div className="behaviour-value">
-                                                    <LabeledInput className="labels" type='number' label='Amplitude' name='amplitude' value={amplitude} onChange={changeAmplitude} />
-                                                    <LabeledInput className="labels" type='number' label='Period(ms)' name='wave_period' value={wave_period} onChange={changeWave_period} />
-                                                </div>
-                                                : behaviour === "Square" ?
-                                                    <div className="behaviour-value">
-                                                        <LabeledInput className="labels" type='number' label='Amplitude' name='amplitude' value={amplitude} onChange={changeAmplitude} />
-                                                        <LabeledInput className="labels" type='number' label='Period(ms)' name='wave_period' value={wave_period} onChange={changeWave_period} />
-                                                    </div>
-                                                    : null
-                    }
-                    {
-                        behaviour !== "" ?
-                            <div className="preview">
-                                <Line
-                                    data={{
-                                        labels: arr,
-                                        datasets: [
-                                            {
-                                                label: "Component Signal",
-                                                data: ar,
-                                                fill: false,
-                                                borderColor: "rgb(0,139,225)",
-                                                borderWidth: 2,
-                                                pointRadius: 0,
-                                            },
-                                        ],
-                                    }}
-                                    options={{
-                                        maintainAspectRatio: true,
-                                        scales: {
-                                            yAxes: [
-                                                {
-                                                    ticks: {
-                                                        beginAtZero: true,
-                                                    },
-                                                },
-                                            ],
-                                            xAxes: [
-                                                {
-                                                    scaleLabel: {
-                                                        display: true,
-                                                        labelString: 'Time (second)',
-                                                        fontColor: "rgb(0,139,225)"
-                                                    }
-                                                }
-                                            ]
-                                        },
-                                        legend: {
-                                            labels: {
-                                                fontSize: 15,
-                                                fontColor: "rgb(0,139,225)",
-                                            },
-                                        },
-                                    }}
-                                />
-                            </div> : null
-                    }
-                </div>
+                <BehaviourComponent behaviour={behaviour} signalArray="" telemetrySendInterval={deviceTwin.telemetrySendInterval} arrayLength={len} setCurrDataArray={setCurrDataArray}/>
             </div >);
         }
-        else {
-            let arr2 = [];
+        else {            
             if (deviceTwin.signalArray[index] === undefined) {
                 setIndex(0);
             }
-            else {
-                if (JSON.parse(deviceTwin.signalArray[index])["Behaviour"] === "Sine") {
-                    const phase = 0;
-                    for (let i = 0; i < len; i++) {
-                        let currData = parseFloat(JSON.parse(deviceTwin.signalArray[index])["Mean"]) + Math.sin((i * (parseFloat(deviceTwin.telemetrySendInterval) / 1000)) * (2 * Math.PI) / (parseFloat(JSON.parse(deviceTwin.signalArray[index])["Wave Period"]) / 1000) + phase) * parseFloat(JSON.parse(deviceTwin.signalArray[index])["Amplitude"]);
-                        arr2.push(currData);
-                    }
-                }
-                else if (JSON.parse(deviceTwin.signalArray[index])["Behaviour"] === "Constant") {
-                    for (let i = 0; i < len; i++) {
-                        let currData = parseFloat(JSON.parse(deviceTwin.signalArray[index])["Mean"]);
-                        arr2.push(currData);
-                    }
-                }
-                else if (JSON.parse(deviceTwin.signalArray[index])["Behaviour"] === "Linear") {
-                    for (let i = 0; i < len; i++) {
-                        let currData = parseFloat(JSON.parse(deviceTwin.signalArray[index])["Slope"]) * (i * (parseFloat(deviceTwin.telemetrySendInterval) / 1000));
-                        arr2.push(currData);
-                    }
-                }
-                else if (JSON.parse(deviceTwin.signalArray[index])["Behaviour"] === "Noise") {
-                    let mean = 0;
-                    let standard_deviation = parseFloat(deviceTwin.noiseSd);
-                    for (let i = 0; i < len; i++) {
-                        let x = (Math.random() - 0.5) * 2;
-                        let noise = (1 / (Math.sqrt(2 * Math.PI) * standard_deviation)) * Math.pow(Math.E, -1 * Math.pow((x - mean) / standard_deviation, 2) / 2);
-                        let noise_mag = JSON.parse(deviceTwin.signalArray[index])["Noise Magnitude"] * Math.sign((Math.random() - 0.5) * 2);
-                        let currData = noise * noise_mag;
-                        arr2.push(currData);
-                    }
-                }
-                else if (JSON.parse(deviceTwin.signalArray[index])["Behaviour"] === "Triangular") {
-                    for (let i = 0; i < len; i++) {
-                        let currData = (2 * parseFloat(JSON.parse(deviceTwin.signalArray[index])["Amplitude"]) * Math.asin(Math.sin((2 * Math.PI * (i * (parseFloat(deviceTwin.telemetrySendInterval) / 1000))) / (parseFloat(JSON.parse(deviceTwin.signalArray[index])["Wave Period"]) / 1000)))) / Math.PI;
-                        arr2.push(currData);
-                    }
-                }
-                else if (JSON.parse(deviceTwin.signalArray[index])["Behaviour"] === "Sawtooth") {
-                    for (let i = 0; i < len; i++) {
-                        let currData = 2 * parseFloat(JSON.parse(deviceTwin.signalArray[index])["Amplitude"]) * ((i * (parseFloat(deviceTwin.telemetrySendInterval) / 1000)) / (parseFloat(JSON.parse(deviceTwin.signalArray[index])["Wave Period"]) / 1000) - Math.floor(1 / 2 + (i * (parseFloat(deviceTwin.telemetrySendInterval) / 1000)) / (parseFloat(JSON.parse(deviceTwin.signalArray[index])["Wave Period"]) / 1000)));
-                        arr2.push(currData);
-                    }
-                }
-                else if (JSON.parse(deviceTwin.signalArray[index])["Behaviour"] === "Square") {
-                    for (let i = 0; i < len; i++) {
-                        let currData = parseFloat(JSON.parse(deviceTwin.signalArray[index])["Amplitude"]) * Math.sign(Math.sin((2 * Math.PI * (i * (parseFloat(deviceTwin.telemetrySendInterval) / 1000))) / (parseFloat(JSON.parse(deviceTwin.signalArray[index])["Wave Period"]) / 1000)));
-                        arr2.push(currData);
-                    }
-                }
+            else {            
                 return (<div>
                     <div className="behaviour-list">
                         <Select value={JSON.parse(deviceTwin.signalArray[index])["Behaviour"]} options={options} style={{ width: "300px" }} disabled={true}></Select>
                     </div>
-                    <div className="behaviour-prop">
-                        {
-                            JSON.parse(deviceTwin.signalArray[index])["Behaviour"] === "Sine" ?
-                                <div className="behaviour-value">
-                                    <LabeledInput className="labels" type='number' label='Mean' name='mean' value={JSON.parse(deviceTwin.signalArray[index])["Mean"]} disabled={true} />
-                                    <LabeledInput className="labels" type='number' label='Amplitude' name='amplitude' value={JSON.parse(deviceTwin.signalArray[index])["Amplitude"]} disabled={true} />
-                                    <LabeledInput className="labels" type='number' label='Period(ms)' name='wave_period' value={JSON.parse(deviceTwin.signalArray[index])["Wave Period"]} disabled={true} />
-                                </div > : JSON.parse(deviceTwin.signalArray[index])["Behaviour"] === "Constant" ?
-                                    <div className="behaviour-value">
-                                        <LabeledInput className="labels" type='number' label='Mean' name='mean' value={JSON.parse(deviceTwin.signalArray[index])["Mean"]} disabled={true} />
-                                    </div > : JSON.parse(deviceTwin.signalArray[index])["Behaviour"] === "Linear" ?
-                                        <div className="behaviour-value">
-                                            <LabeledInput className="labels" type='number' label='Slope' name='slope' value={JSON.parse(deviceTwin.signalArray[index])["Slope"]} disabled={true} />
-                                        </div > : JSON.parse(deviceTwin.signalArray[index])["Behaviour"] === "Noise" ?
-                                            <div className="behaviour-value">
-                                                <LabeledInput className="labels" type='number' label='Magnitude' name='noise_magnitude' value={JSON.parse(deviceTwin.signalArray[index])["Noise Magnitude"]} disabled={true} />
-                                                <LabeledInput className="labels" type='number' label='Deviation' name='noiseSd' value={0.45} disabled={true} />
-                                            </div > : JSON.parse(deviceTwin.signalArray[index])["Behaviour"] === "Triangular" ?
-                                                <div className="behaviour-value">
-                                                    <LabeledInput className="labels" type='number' label='Amplitude' name='amplitude' value={JSON.parse(deviceTwin.signalArray[index])["Amplitude"]} disabled={true} />
-                                                    <LabeledInput className="labels" type='number' label='Period(ms)' name='wave_period' value={JSON.parse(deviceTwin.signalArray[index])["Wave Period"]} disabled={true} />
-                                                </div > : JSON.parse(deviceTwin.signalArray[index])["Behaviour"] === "Sawtooth" ?
-                                                    <div className="behaviour-value">
-                                                        <LabeledInput className="labels" type='number' label='Amplitude' name='amplitude' value={JSON.parse(deviceTwin.signalArray[index])["Amplitude"]} disabled={true} />
-                                                        <LabeledInput className="labels" type='number' label='Period(ms)' name='wave_period' value={JSON.parse(deviceTwin.signalArray[index])["Wave Period"]} disabled={true} />
-                                                    </div > : JSON.parse(deviceTwin.signalArray[index])["Behaviour"] === "Square" ?
-                                                        <div className="behaviour-value">
-                                                            <LabeledInput className="labels" type='number' label='Amplitude' name='amplitude' value={JSON.parse(deviceTwin.signalArray[index])["Amplitude"]} disabled={true} />
-                                                            <LabeledInput className="labels" type='number' label='Period(ms)' name='wave_period' value={JSON.parse(deviceTwin.signalArray[index])["Wave Period"]} disabled={true} />
-                                                        </div > : null
-                        }
-                        <div className="preview">
-                            <Line
-                                data={{
-                                    labels: arr,
-                                    datasets: [
-                                        {
-                                            label: "Component Signal",
-                                            data: arr2,
-                                            fill: false,
-                                            borderColor: "rgb(0,139,225)",
-                                            borderWidth: 2,
-                                            pointRadius: 0,
-                                        },
-                                    ],
-                                }}
-                                options={{
-                                    maintainAspectRatio: true,
-                                    scales: {
-                                        yAxes: [
-                                            {
-                                                ticks: {
-                                                    beginAtZero: true,
-                                                },
-                                            },
-                                        ],
-                                        xAxes: [
-                                            {
-                                                scaleLabel: {
-                                                    display: true,
-                                                    labelString: 'Seconds',
-                                                    fontColor: "rgb(0,139,225)"
-                                                }
-                                            }
-                                        ]
-                                    },
-                                    legend: {
-                                        labels: {
-                                            fontSize: 15,
-                                            fontColor: "rgb(0,139,225)",
-                                        },
-                                    },
-                                }}
-                            />
-                        </div>
-                    </div >
+                    <BehaviourComponent behaviour={JSON.parse(deviceTwin.signalArray[index])["Behaviour"]} signalArray={deviceTwin.signalArray[index]} telemetrySendInterval={deviceTwin.telemetrySendInterval} arrayLength={len} setCurrDataArray={setCurrDataArray}/>
                 </div>);
             }
         }
-    };
+    };    
+     
 
     return (
         <>
@@ -622,54 +334,13 @@ export function DeviceTwin(props) {
                             </div>
                             <div className="behaviour-area">
                                 <InputGroup label='No. of datapoints' displayStyle="inline">
-                                    <Radio name="choice" value={10} label={'10'} onChange={handleLength} />
-                                    <Radio name="choice" value={50} label={'50'} onChange={handleLength} />
-                                    <Radio name="choice" value={100} label={'100'} onChange={handleLength} />
+                                    <Radio name="choice" value={10} label={'10'} onChange={handleLength} checked={parseFloat(len) === 10?true:false}/>
+                                    <Radio name="choice" value={50} label={'50'} onChange={handleLength} checked={parseFloat(len) === 50?true:false}/>
+                                    <Radio name="choice" value={100} label={'100'} onChange={handleLength} checked={parseFloat(len) === 100?true:false}/>
                                 </InputGroup>
-                                <div className="main-preview">
-                                    <Line
-                                        data={{
-                                            labels: arr,
-                                            datasets: [
-                                                {
-                                                    label: "Composite Signal",
-                                                    data: currDataArray,
-                                                    fill: false,
-                                                    borderColor: "rgb(0,139,225)",
-                                                    borderWidth: 2,
-                                                    pointRadius: 0,
-                                                },
-                                            ],
-                                        }}
-                                        options={{
-                                            maintainAspectRatio: true,
-                                            scales: {
-                                                yAxes: [
-                                                    {
-                                                        ticks: {
-                                                            beginAtZero: true,
-                                                        },
-                                                    },
-                                                ],
-                                                xAxes: [
-                                                    {
-                                                        scaleLabel: {
-                                                            display: true,
-                                                            labelString: 'Seconds',
-                                                            fontColor: "rgb(0,139,225)"
-                                                        }
-                                                    }
-                                                ]
-                                            },
-                                            legend: {
-                                                labels: {
-                                                    fontSize: 15,
-                                                    fontColor: "rgb(0,139,225)",
-                                                },
-                                            },
-                                        }}
-                                    />
-                                </div>
+
+                                <ChartComponent labelsArray={arr} dataArray={currDataArray} chartName="Composite Signal"/>
+                                
                                 {deviceTwin.signalArray && !deviceTwin.valueIsBool ?
                                     <HorizontalTabs
                                         style={{ overflow: "scroll", width: "400px" }}

--- a/IoTDeviceSimulator/web-client/src/DeviceTwin.js
+++ b/IoTDeviceSimulator/web-client/src/DeviceTwin.js
@@ -100,6 +100,7 @@ export function DeviceTwin(props) {
 
     const updateDeviceTwin = useCallback(async (event) => {
         event.preventDefault();
+        setNewBehaviour("");
         let updatedDevice = false;
         if (deviceTwin.signalArray[deviceTwin.signalArray.length - 1] === "") {
             deviceTwin.signalArray.pop();


### PR DESCRIPTION
- Add UI for behaviours in non-admin mode
- Refactor Behaviour component

In an earlier [PR](https://github.com/iTwin/iot-demo/pull/163), we added a feature to define behavior (simulated data pattern) for IoT devices for admin users. Because only admin users can add/edit behavior for a device. Non-admin users can only view the already-defined device behavior. So these changes are required for non-admin users to appropriately see the device behavior in the device list.